### PR TITLE
Automatic update of Costura.Fody to 6.0.0

### DIFF
--- a/src/YouCast/YouCast.csproj
+++ b/src/YouCast/YouCast.csproj
@@ -91,7 +91,10 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="[4.0.0]" />
+    <PackageReference Include="Costura.Fody" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="YoutubeExplode">
       <Version>6.5.2</Version>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a major update of `Costura.Fody` to `6.0.0` from `4.0.0`
`Costura.Fody 6.0.0` was published at `2024-11-28T20:54:19Z`, 3 months ago

1 project update:
Updated `src/YouCast/YouCast.csproj` to `Costura.Fody` `6.0.0` from `4.0.0`

[Costura.Fody 6.0.0 on NuGet.org](https://www.nuget.org/packages/Costura.Fody/6.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
